### PR TITLE
Versions: return an ordered DESC list of comments

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -66,7 +66,7 @@ type Source struct {
   MapCommentMeta         bool   `json:"map_comment_meta"`
   ReviewStates         []string `json:"review_states"`
   When                   string `json:"when"` // all, latest, first
-  
+
   IgnoreStates         []string `json:"ignore_states"`
   IgnoreLabels         []string `json:"ignore_labels"`
   IgnoreComments       []string `json:"ignore_comments"`
@@ -74,6 +74,7 @@ type Source struct {
 
 // Version communicated with Concourse.
 type Version struct {
+  CreatedAt string `json:"created_at"`
   PrID      string `json:"pr_id"`
   ReviewID  string `json:"review_id"`
   CommentID string `json:"comment_id"`
@@ -137,7 +138,7 @@ func (source *Source) requestsState(state string) bool {
       }
     }
   }
-  
+
   // Ensure ignored states
   for _, s := range source.IgnoreStates {
     if s == state {

--- a/actions/check.go
+++ b/actions/check.go
@@ -157,6 +157,7 @@ func Check(req CheckRequest) (*CheckResponse, error) {
 
       // Add the comment ID to the list of versions we want Concourse to see
       version = &Version{
+        CreatedAt: strconv.FormatInt(comment.CreatedAt.Unix(), 10),
         PrID:      strconv.Itoa(*pull.Number),
         CommentID: strconv.FormatInt(*comment.ID, 10),
       }
@@ -201,6 +202,7 @@ func Check(req CheckRequest) (*CheckResponse, error) {
 
       // Add the comment ID to the list of versions we want Concourse to see
       version = &Version{
+        CreatedAt: strconv.FormatInt(review.SubmittedAt.Unix(), 10),
         PrID:     strconv.Itoa(*pull.Number),
         ReviewID: strconv.FormatInt(*review.ID, 10),
       }
@@ -223,7 +225,7 @@ func Check(req CheckRequest) (*CheckResponse, error) {
   }
 
   sort.Slice(versions, func(i, j int) bool {
-    return versions[i].CommentID < versions[j].CommentID
+    return versions[i].CreatedAt < versions[j].CreatedAt
   })
 
   return &versions, nil


### PR DESCRIPTION
Github doesn't return a sorted list of comments by default.
In order to have versions triggering correctly, this patch orders the versions by comment_id in order to always have the last comments seen by concourse

Close #1