### PR TITLE
Idempotent label removal

### DIFF
--- a/api/github.go
+++ b/api/github.go
@@ -303,7 +303,7 @@ func (c *GithubClient) AddPullRequestLabels(prID int, labels []string) error {
 // labels given the relative pull request ID to the configured repo
 func (c *GithubClient) RemovePullRequestLabels(prID int, labels []string) error {
   for _, l := range labels {
-    _, err := c.Client.Issues.RemoveLabelForIssue(
+    response, err := c.Client.Issues.RemoveLabelForIssue(
       context.TODO(),
       c.Owner,
       c.Repository,
@@ -311,7 +311,7 @@ func (c *GithubClient) RemovePullRequestLabels(prID int, labels []string) error 
       l,
     )
     
-    if err != nil {
+    if err != nil && response.StatusCode != http.StatusNotFound {
       return err
     }
   }


### PR DESCRIPTION
First, thanks for this plugin, it's making my life a lot easier!

In case I'm trying to delete a label that doesn't exist, my pipeline fails because. 
Delete should be idempotent and shouldn't make a pipeline fail if a label doesn't exist.